### PR TITLE
fix boundingbox & infinity loop

### DIFF
--- a/src/ofxMultiLineText.cpp
+++ b/src/ofxMultiLineText.cpp
@@ -32,7 +32,7 @@ void ofxMultiLineText::drawString(std::string text, float x, float y, Adjustment
 ofRectangle ofxMultiLineText::getStringBoundingBox(std::string text, float x, float y, Adjustment adjust){
 	switch(adjust){
 		case Left:
-			return getStringBoundingBox(text,x,y,adjust);
+			return getStringBoundingBox(text,x,y);
 			break;
 		case Center:{
 			ofRectangle bb;
@@ -46,6 +46,7 @@ ofRectangle ofxMultiLineText::getStringBoundingBox(std::string text, float x, fl
 				bb = bb.getUnion(thisbb);
 				yp += getLineHeight();
 			}
+			bb.x += bb.width/2.f;
 			return bb;
 			break;
 		}


### PR DESCRIPTION
to draw a truetypefont label centered vertically & horizontally I usally do this:

```
ofRectangle bb = font.getStringBoundingBox(typeStr,0,0);
ofTranslate(-bb.x-bb.width/2.f,-bb.y-bb.height/2.f);
font.drawString(typeStr, 0,0);
```

this wasn't working the same way with centered alignment in ofxMultiLineText until I modified the bb.x.

It was a quick fix to be honest, found the fix by observation not by checking your algorithm ...

The fix for the infinity loop was more obvious.
